### PR TITLE
ODP-6224: Upgrade bcprov dependency to jdk18on (1.78) in phoenix-queryserver-it to fix undeclared dependency issue

### DIFF
--- a/phoenix-queryserver-it/pom.xml
+++ b/phoenix-queryserver-it/pom.xml
@@ -190,8 +190,8 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.68</version>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.78</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://accelcentral.atlassian.net/browse/ODP-6224

This patch was tested locally.