### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 
         <gson.version>2.10.1</gson.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
-        <netty-bom.version>4.1.119.Final</netty-bom.version>
+        <netty-bom.version>4.1.132.Final</netty-bom.version>
         <commons-io.version>2.18.0</commons-io.version>
         <sqlline.version>1.9.0</sqlline.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
This patch was tested locally.